### PR TITLE
Add NSCalendarsUsageDescription key to Info.plist

### DIFF
--- a/app/App_Resources/iOS/Info.plist
+++ b/app/App_Resources/iOS/Info.plist
@@ -62,5 +62,7 @@
 		<string>Icon-40@2x.png</string>
 		<string>Icon-40.png</string>
 	</array>
+	<key>NSCalendarsUsageDescription</key>
+	<string>This app would like to access your calendar.</string>
 </dict>
 </plist>


### PR DESCRIPTION
It is required by *TKCalendarView* in *TelerikUI.framework* of `nativescript-telerik-ui-pro@1.5.1` on iOS 10.