### PR TITLE
Add postinstall script to setup firebase plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "typescript": "~2.1.5",
     "shelljs": "^0.5.3"
   },
+  "scripts": {
+    "postinstall" : "(cd node_modules/nativescript-plugin-firebase && npm run setup)"
+  },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
In nativescript-plugin-firebase@3.9.3, the postinstall script was removed due to prompt swallowing with {N} CLI 2.5.0.

Add postinstall script to the app in order to be able to clone and run directly.

Details:
https://github.com/NativeScript/nativescript-cli/issues/2521
https://github.com/EddyVerbruggen/nativescript-plugin-firebase#installation