### PR TITLE
Fixed issues with main content being cutoff

### DIFF
--- a/app/App_Resources/Android/values/styles.xml
+++ b/app/App_Resources/Android/values/styles.xml
@@ -27,6 +27,7 @@
         <item name="popupTheme">@style/ThemeOverlay.AppCompat</item>
 
         <item name="contentInsetStart">72dip</item>
+        <item name="android:paddingTop">24dp</item>
     </style>
 	<style name="NativeScriptToolbarStyle" parent="NativeScriptToolbarStyleBase">
     </style>

--- a/app/app.android.css
+++ b/app/app.android.css
@@ -15,10 +15,6 @@
     color: white;
 }
 
-ActionBar {
-    margin: 25 0 0 0;
-}
-
 .example-title-list, .example-title-wrap {
     color: black;
     margin: 3;

--- a/app/views/main-page/main-page.xml
+++ b/app/views/main-page/main-page.xml
@@ -34,7 +34,7 @@
         </drawer:RadSideDrawer.drawerContent>
         <drawer:RadSideDrawer.mainContent>
             <GridLayout>
-                <GridLayout class="page-content" android:margin="24 0 0 0">
+                <GridLayout class="page-content">
                     <ScrollView id="content" opacity="0">
                         <GridLayout>
                             <Repeater items="{{ featuredExamples }}" android:margin="10" ios:margin="6">


### PR DESCRIPTION
This PR resolved the issue that appeared after yesterdays fix to the `margin` of the `ActionBar` not being reflected by the RadSideDrawer component from the nativescript-telerik-ui-pro plugin when used with `showOverNavigation` set to `true`.