### PR TITLE
fix: Crash due to writing to statusBarStyle

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -41,7 +41,6 @@ if (application.android) {
 
 if (application.ios) {
     application.on("launch", args => {
-        utils.ios.getter(UIApplication, UIApplication.sharedApplication).statusBarStyle = UIStatusBarStyle.UIStatusBarStyleLightContent;
         setTimeout(() => {
             utils.ios.getter(UIApplication, UIApplication.sharedApplication).keyWindow.backgroundColor = utils.ios.getter(UIColor, UIColor.blackColor);
         }, 1);


### PR DESCRIPTION
The latest iOS Runtime exposes UIApplication's statusBarStyle
property as read-only because write access to it has been deprecated
since iOS 9.0. The status bar's style is automatically adjusted and
this code should not be needed.

See https://developer.apple.com/documentation/uikit/uiapplication/1622988-statusbarstyle?language=objc

The new behavior in iOS is introduced with NativeScript/ios-runtime#1100