### PR TITLE
fix(android): items laid out in one col on some devices

### DIFF
--- a/app/views/main-page/main-page.xml
+++ b/app/views/main-page/main-page.xml
@@ -59,10 +59,10 @@
                         <Repeater.itemsLayout>
                             <WrapLayout id="examples-wrap-layout" 
                                 horizontalAlignment="left" 
-                                android:itemWidth="{{ (screenWidth - 20) / 2 }}" 
+                                android:itemWidth="{{ (screenWidth - 21) / 2 }}" 
                                 ios:itemWidth="{{ (screenWidth - 13) / 2 }}" 
-                                android:itemHeight="{{ (screenWidth - 20) * 0.5 + 50 }}" 
-                                ios:itemHeight="{{ (screenWidth - 13) * 0.5 + 50 }}" />
+                                android:itemHeight="{{ (screenWidth - 21) / 2 + 50 }}" 
+                                ios:itemHeight="{{ (screenWidth - 13) / 2 + 50 }}" />
                         </Repeater.itemsLayout>
                         <Repeater.itemTemplate>
                             <GridLayout class="example-intro" 


### PR DESCRIPTION
Fixed: Example items are shown in one column in some android phones:
![Screenshot_20191018-100044](https://user-images.githubusercontent.com/4092076/67099646-066b6c00-f1c7-11e9-9e68-cda296cf0732.png)